### PR TITLE
Add Type Definitions, bump to version `0.2.1`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,10 @@
+export function encode(uint8array: Uint8Array): string;
+
+export function decode(base64: string): Uint8Array;
+
+declare const uint8ToBase64: {
+  encode: typeof encode;
+  decode: typeof decode;
+};
+
+export default uint8ToBase64; 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uint8-to-base64",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "A safe Uint8Array to base64 string converter",
   "main": "cjs/index.js",
   "scripts": {
@@ -43,5 +43,6 @@
   "bugs": {
     "url": "https://github.com/WebReflection/uint8-to-base64/issues"
   },
-  "homepage": "https://github.com/WebReflection/uint8-to-base64#readme"
+  "homepage": "https://github.com/WebReflection/uint8-to-base64#readme",
+  "types": "index.d.ts"
 }


### PR DESCRIPTION
Adds Type Definitions, Solves https://github.com/WebReflection/uint8-to-base64/issues/3 and complaints from typescript like:
```
Could not find a declaration file for module 'uint8-to-base64'. './node_modules/uint8-to-base64/cjs/index.js' implicitly has an 'any' type.
  Try `npm i --save-dev @types/uint8-to-base64` if it exists or add a new declaration (.d.ts) file containing `declare module 'uint8-to-base64';`ts(7016)
```

Surprised to find the browser's [`Uint8Array.prototype.toBase64()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/toBase64) not widely supported and don't want to have a function in my code solving something I expect to be a standard, so I found this package and found it really useful. Typescript errors annoyed me, so I made this PR.